### PR TITLE
[ProStreet] Make compatible with 1.1 releases

### DIFF
--- a/SOURCE/NFSPS/dllmain.cpp
+++ b/SOURCE/NFSPS/dllmain.cpp
@@ -298,15 +298,13 @@ BOOL APIENTRY DllMain(HMODULE /*hModule*/, DWORD reason, LPVOID /*lpReserved*/)
 	if (reason == DLL_PROCESS_ATTACH)
 	{
 		uintptr_t base = (uintptr_t)GetModuleHandleA(NULL);
-		IMAGE_DOS_HEADER* dos = (IMAGE_DOS_HEADER*)(base);
-		IMAGE_NT_HEADERS* nt = (IMAGE_NT_HEADERS*)(base + dos->e_lfanew);
 
-		if ((base + nt->OptionalHeader.AddressOfEntryPoint + (0x400000 - base)) == 0x00828C25) // Check if .exe file is compatible - Thanks to thelink2012 and MWisBest
+		if (strstr((const char*)(base + (0xA49742 - base)), "ProStreet08Release.exe"))
 			Init();
 
 		else
 		{
-			MessageBoxA(NULL, "This .exe is not supported.\nPlease use v1.1 NFS.exe from BATTERY (27,4 MB (28.739.656 bytes)).", "NFSPS HD Content Support by Aero_", MB_ICONERROR);
+			MessageBoxA(NULL, "This .exe is not supported.\nPlease use a NOCD v1.1 NFS.exe.", "NFSPS HD Content Support by Aero_", MB_ICONERROR);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
Basically the same as AeroWidescreen/NFSHDReflections#2

Because the ViTALITY exe is protected and dumps its contents to memory during launch, the nt+base call would default to NULL. Everything else in the exe is perfectly aligned with other exe files.